### PR TITLE
security: bump 16 package(s) in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "clsx": "^2.1.0",
     "kysely": "^0.27.2",
     "lucide-react": "^0.321.0",
-    "next": "14.2.35",
+    "next": "15.0.8",
     "react": "^18",
     "react-dom": "^18",
     "swr": "^2.2.4",
@@ -42,5 +42,8 @@
     "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "next": "14.1.1"
   }
 }


### PR DESCRIPTION
## Security dependency upgrade

This PR was opened by **depagent** to address **16 security alert(s)** in the `npm` ecosystem.

Each package is pinned to **exactly** the patched version reported by Dependabot's `first_patched_version` — not a range. To restore a range constraint (e.g. `^x.y.z`), edit the manifest after merge.

### Alerts addressed

| Sev | Package | Vulnerable range | Patched | CVE | GHSA | EPSS | KEV |
|---|---|---|---|---|---|---|---|
| critical | `next` | >= 14.0.0, < 14.2.25 | 14.2.25 | CVE-2025-29927 | GHSA-f82v-jwr5-mffw | 0.92 | no |
| high | `next` | >= 12.2.0, < 15.5.16 | 15.5.16 | CVE-2026-44573 | GHSA-36qx-fr4f-26g5 | 0.00 | no |
| high | `next` | >= 13.0.0, < 15.5.16 | 15.5.16 | - | GHSA-8h8q-6873-q5fj | - | no |
| high | `next` | >= 13.4.13, < 15.5.16 | 15.5.16 | CVE-2026-44578 | GHSA-c4j6-fc7j-m34r | 0.04 | no |
| high | `next` | >= 12.2.0, < 15.5.16 | 15.5.16 | CVE-2026-44573 | GHSA-36qx-fr4f-26g5 | 0.00 | no |
| high | `next` | >= 13.4.13, < 15.5.16 | 15.5.16 | CVE-2026-44578 | GHSA-c4j6-fc7j-m34r | 0.04 | no |
| high | `next` | >= 13.0.0, < 15.5.16 | 15.5.16 | - | GHSA-8h8q-6873-q5fj | - | no |
| high | `next` | >= 13.0.0, < 15.5.15 | 15.5.15 | - | GHSA-q4gf-8mx6-v5v3 | - | no |
| high | `next` | >= 13.0.0, < 15.5.15 | 15.5.15 | - | GHSA-q4gf-8mx6-v5v3 | - | no |
| high | `next` | >= 13.0.0, < 15.0.8 | 15.0.8 | - | GHSA-h25m-26qc-wcjf | - | no |
| high | `next` | >= 13.0.0, < 15.0.8 | 15.0.8 | - | GHSA-h25m-26qc-wcjf | - | no |
| high | `next` | >= 13.3.1-canary.0, < 14.2.35 | 14.2.35 | - | GHSA-5j59-xgg2-r9c4 | - | no |
| high | `next` | >= 13.3.0, < 14.2.34 | 14.2.34 | - | GHSA-mwv6-3258-q52c | - | no |
| high | `next` | >= 9.5.5, < 14.2.15 | 14.2.15 | CVE-2024-51479 | GHSA-7gfc-8cq8-jh5f | 0.76 | no |
| high | `next` | >= 14.0.0, < 14.2.10 | 14.2.10 | CVE-2024-46982 | GHSA-gp8f-8m3g-qvj9 | 0.49 | no |
| high | `next` | >= 13.4.0, < 14.1.1 | 14.1.1 | CVE-2024-34351 | GHSA-fr5h-rqp8-mj6g | 0.93 | no |

### Notes
- Some changes are **package overrides** for transitive vulnerable deps (`pnpm.overrides` / `overrides` / `resolutions`). The vulnerable package isn't declared directly in the manifest — the override pins it to the patched version across the entire dependency graph for that workspace.
- ⚠️ Lockfile NOT regenerated: npm failed: npm warn Unknown user config "audit-signatures". This will stop working in the next major version of npm.
npm error code EOVERRIDE
npm error Override for next@15.0.8 conflicts with direct dependency
npm error A complete log of this run can be found in: /Users/securient/.npm/_logs/2026-05-19T23_00_59_660Z-debug-0.log. Please run your package manager's install locally and commit the lockfile update.

_Generated by depagent — `storyprotocol/ethdenver-activation`._
